### PR TITLE
Minor changes for consistency across release notes.

### DIFF
--- a/rst/dev-guide/conf.py
+++ b/rst/dev-guide/conf.py
@@ -37,7 +37,7 @@ extensions = [
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+#templates_path = ['_templates']
 
 # The suffix of source filenames.
 source_suffix = '.rst'
@@ -128,7 +128,8 @@ extlinks = {
 rst_epilog = """
 .. |apiservice| replace:: Rackspace Cloud Files API
 .. |no changes| replace:: None for this release.
-.. |contract version| replace:: v1
+.. |contract version| replace:: 1.0
+.. |product name| replace:: Rackspace Cloud Files
 """
 
 

--- a/rst/dev-guide/release-notes.rst
+++ b/rst/dev-guide/release-notes.rst
@@ -4,25 +4,27 @@
 **Release Notes**
 ======================
 
-This section describes, for each release, the new features, changes to existing features, 
-and any known issues.
+Learn about new features, enhancements, known issues, resolved issues, and other important 
+details about |apiservice| |contract version| service updates.
+
+.. note:: For information about using the API, see the :ref:`documentation overview <index>`.
 
 .. toctree::
    :maxdepth: 2  
       
-   release-notes/cf-v1-20150226
-   release-notes/cf-v1-20141217    
-   release-notes/cf-v1-20140828
-   release-notes/cf-v1-20140718
-   release-notes/cf-v1-20140430  
-   release-notes/cf-v1-20140401
-   release-notes/cf-v1-20140221
-   release-notes/cf-v1-20131231
-   release-notes/cf-v1-20130926
-   release-notes/cf-v1-20130520 
-   release-notes/cf-v1-20121205
-   release-notes/cf-v1-20121116
-   release-notes/cf-v1-20121001
-   release-notes/cf-v1-20120925 
-   release-notes/cf-v1-20120813
-   release-notes/cf-v1-20120601
+   February 26, 2015 <release-notes/cf-v1-20150226>
+   December 17, 2014 <release-notes/cf-v1-20141217>    
+   August 28, 2014 <release-notes/cf-v1-20140828>
+   July 18, 2014 <release-notes/cf-v1-20140718>
+   April 30, 2014 <release-notes/cf-v1-20140430>  
+   April 1, 2014 <release-notes/cf-v1-20140401>
+   February 21, 2014 <release-notes/cf-v1-20140221>
+   December 31, 2013 <release-notes/cf-v1-20131231>
+   September 26, 2013 <release-notes/cf-v1-20130926>
+   May 20, 2013 <release-notes/cf-v1-20130520>
+   December 05, 2012 <release-notes/cf-v1-20121205>
+   November 16, 2012 <release-notes/cf-v1-20121116>
+   October 01, 2012 <release-notes/cf-v1-20121001>
+   September 25, 2012 <release-notes/cf-v1-20120925> 
+   August 13, 2012 <release-notes/cf-v1-20120813>
+   June 01, 2012 <release-notes/cf-v1-20120601>


### PR DESCRIPTION
- Updated global variables section in conf.py to change contract version to "1.0" .  We'll use v#.# to refer to release version identifiers for services that have them.

- In the Release Notes intro, added a link to top of API doc.

- In the Release Notes, added a navigation title with date to prevent repetition of "API 1.0" in the Release Notes navigation headers.