### PR TITLE
Remove incorrect mentions in "Language-specific APIs" section

### DIFF
--- a/api-docs/concepts.rst
+++ b/api-docs/concepts.rst
@@ -181,23 +181,12 @@ in the hands of developers. These language-specific APIs provide a layer
 of abstraction on top of the base REST API, enabling developers to work
 with a container and object model instead of working directly with HTTP
 requests and responses. The language-specific APIs are available at no
-cost to download, use, and modify. They are licensed under the MIT
-license as described in the COPYING file packaged with each API.
-
-If you make any improvements to a Cloud File language-specific API, you
-are encouraged (but not required) to submit those changes back to
-Rackspace. If you want to suggest changes to an API, send an email to
-sdk-support@rackspace.com. Be sure to indicate which language and
-version you modified and send a unified ``diff``.
+cost to download, use, and modify.
 
 Detailed information about the language-specific APIs is in the
 Rackspace Cloud SDKs Software Development Kit Guide. Each API has its
 own documentation (in HTML, PDF, or CHM format) including code snippets
 and examples to help you get started.
-
-You are welcome to create your own language-specific APIs. Rackspace
-will help answer any questions during development, host your code if you
-like, and give you full credit for your work.
 
 For more information about the Rackspace SDKs, see :rax-dev:`SDKs and tools<sdks>`.
 


### PR DESCRIPTION
The "Language-specific APIs" section of the [concepts](https://developer.rackspace.com/docs/cloud-files/v1/developer-guide/#language-specific-apis) page references a few things that aren't accurate and should be removed.

* Most of our SDKs are Apache 2 licensed, but that's really something
  specific to the projects in general and can't be captured by a
  catch-all mention.
* While people are generally encouraged to contribute their changes
  back upstream, that's never been done by sending a diff to the email
  list. Each particular project has their methods and processes
  of accepting changes, generally via pull requests. While we'd take a
  diff and find a way to get it into a release, we shouldn't be
  advertising that as the way.
* We will not host code for people.