### PR TITLE
Fixes #72 - update the DELETE description for CDN-enabled containers

### DIFF
--- a/api-docs/cdn-api-operations/methods/delete-delete-cdn-enabled-object-v1-account-container-object.rst
+++ b/api-docs/cdn-api-operations/methods/delete-delete-cdn-enabled-object-v1-account-container-object.rst
@@ -12,6 +12,9 @@ This operation deletes CDN-enabled objects.
 
 When you find it necessary to remove a CDN-enabled object from public access before the TTL expires, you can perform a ``DELETE`` operation against the object, or you can create a support ticket to purge the entire container.
 
+To delete containers that have been CDN-enabled in the past and are now disabled, but are still showing up when you use the :ref:`List CDN-enabled containers<list-cdn-enabled-containers>` operation, send a DELETE request with an ``x-remove-cdn-container: t`` header to remove them from the listing.
+
+
 .. warning::
    You request this operation against a CDN management services URI, such as ``https://cdn2.clouddrive.com/v1/MossoCloudFS_aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee``/, as shown in the table “Regionalized service endpoints for CDN management service” in the :ref:`Service Access endpoints <service-access>` section. If you use a Storage management services URI by mistake, you delete your object.
    
@@ -42,6 +45,8 @@ Here is an example response for hitting the purge rate limit:
    Content-Type: text/html; charset=UTF-8 
    X-Trans-Id: txb63f31d26bf84c058542b-0055101cd0dfw1 
    Date: Mon, 23 Mar 2015 14:01:52 GMT
+
+
 
 **By creating a support ticket to purge an entire container**
 

--- a/api-docs/cdn-api-operations/methods/get-list-cdn-enabled-containers-v1-account.rst
+++ b/api-docs/cdn-api-operations/methods/get-list-cdn-enabled-containers-v1-account.rst
@@ -16,6 +16,8 @@ The list is returned in the response body, one container name per line.
 
 An HTTP response status code of 200 through 299 indicates success. A 200 (OK) code is returned if there are containers to list, and a 204 (No Content) code is returned if there are no containers to list.
 
+For instructions about how to delete containers that were CDN-enabled in the past and are now disabled, but are showing in the listing, see :ref:`Delete CDN-enabled object<delete-cdn-enabled-object>`.
+
 To view the CDN container details, see :ref:`List metadata for CDN-enabled container <list-metadata-for-cdn-enabled-container>`.
 
 


### PR DESCRIPTION
...to describe out to delete disabled containers that are still showing
in the list of cdn-enabled containers and added reference to DELETE
from the GET operation description.