### PR TITLE
Streaming docs update

### DIFF
--- a/api-docs/cdn-api-reference/cdn-container-services-operations.rst
+++ b/api-docs/cdn-api-reference/cdn-container-services-operations.rst
@@ -17,7 +17,9 @@ container.
 
 When you enable a container in the CDN service, you automatically generate URIs
 for SSL and streaming usage. They are listed under the X-Cdn-Ssl-Uri and
-X-Cdn-Streaming-Uri/X-Cdn-Ios-Uri headers. **Note:** X-Cdn-Streaming-Uri and X-Cdn-Ios-Uri streaming links will be discontinued on July 31, 2022.
+X-Cdn-Streaming-Uri/X-Cdn-Ios-Uri headers. 
+
+**Note:** X-Cdn-Streaming-Uri and X-Cdn-Ios-Uri streaming links will be discontinued on July 31, 2022.
 
 On August 13, 2012, the format of new CDN URIs changed in order to enhance the
 security of the CDN. Any URIs set in the older format

--- a/api-docs/cdn-api-reference/cdn-container-services-operations.rst
+++ b/api-docs/cdn-api-reference/cdn-container-services-operations.rst
@@ -17,7 +17,7 @@ container.
 
 When you enable a container in the CDN service, you automatically generate URIs
 for SSL and streaming usage. They are listed under the X-Cdn-Ssl-Uri and
-X-Cdn-Streaming-Uri headers.
+X-Cdn-Streaming-Uri/X-Cdn-Ios-Uri headers. **Note:** X-Cdn-Streaming-Uri and X-Cdn-Ios-Uri streaming links will be discontinued on July 31, 2022.
 
 On August 13, 2012, the format of new CDN URIs changed in order to enhance the
 security of the CDN. Any URIs set in the older format

--- a/api-docs/cdn-api-reference/methods/get-list-cdn-enabled-containers-v1-account.rst
+++ b/api-docs/cdn-api-reference/methods/get-list-cdn-enabled-containers-v1-account.rst
@@ -128,6 +128,8 @@ Response
 
 **Example: List CDN-enabled containers HTTP response, using a query parameter ?format=json​**
 
+**Note:** X-Cdn-Streaming-Uri and X-Cdn-Ios-Uri links will be discontinued on July 31, 2022. 
+
 .. code::
 
    HTTP/1.1 200 OK
@@ -139,10 +141,10 @@ Response
    [
        {
            "cdn_enabled": true,
-           "cdn_ios_uri": "http://acc3b9ba6a79805f5577-e7e60117100ffd73b45850c0b1fd96c1.iosr.cf5.rackcdn.com",
-           "cdn_ssl_uri": "https://83c49b9a2f7ad18250b3-346eb45fd42c58ca13011d659bfc1ac1. ssl.cf0.rackcdn.com",
-           "cdn_streaming_uri": "http://084cc2790632ccee0a12-346eb45fd42c58ca13011d659bfc1ac1. r49.stream.cf0.rackcdn.com",
-           "cdn_uri": "http://081e40d3ee1cec5f77bf-346eb45fd42c58ca13011d659bfc1ac1.r49.cf0.rackcdn.com",
+           "X-Cdn-Ios-Uri": "http://acc3b9ba6a79805f5577-e7e60117100ffd73b45850c0b1fd96c1.iosr.cf5.rackcdn.com",
+           "X-Cdn-Ssl-Uri": "https://83c49b9a2f7ad18250b3-346eb45fd42c58ca13011d659bfc1ac1. ssl.cf0.rackcdn.com",
+           "X-Cdn-Streaming-Uri": "http://084cc2790632ccee0a12-346eb45fd42c58ca13011d659bfc1ac1. r49.stream.cf0.rackcdn.com",
+           "X-Cdn-Uri": "http://081e40d3ee1cec5f77bf-346eb45fd42c58ca13011d659bfc1ac1.r49.cf0.rackcdn.com",
            "log_retention": false,
            "name": "cdn_test",
            "ttl": 259200

--- a/api-docs/cdn-api-reference/methods/head-list-metadata-for-cdn-enabled-container-v1-account-container.rst
+++ b/api-docs/cdn-api-reference/methods/head-list-metadata-for-cdn-enabled-container-v1-account-container.rst
@@ -120,16 +120,22 @@ This table shows the header parameters for the response:
 |                          |                         |streaming that uses HTTP|
 |                          |                         |Dynamic Streaming from  |
 |                          |                         |Adobe.                  |
+|                          |                         |**To be discontinued**  | 
+|                          |                         |**July 31, 2022**       |
 +--------------------------+-------------------------+------------------------+
 |X-Cdn-Ios-Uri             |String                   |The URI for video       |
 |                          |                         |streaming that uses HTTP|
 |                          |                         |Live Streaming from     |
 |                          |                         |Apple.                  |
+|                          |                         |**To be discontinued**  | 
+|                          |                         |**July 31, 2022**       |
 +--------------------------+-------------------------+------------------------+
 
 This operation does not return a response body.
 
 **Example: Get CDN-enabled container metadata HTTP response**
+
+**Note:** X-Cdn-Streaming-Uri and X-Cdn-Ios-Uri links will be discontinued on July 31, 2022.
 
 .. code::
 

--- a/api-docs/cdn-api-reference/methods/post-update-cdn-enabled-container-metadata-v1-account-container.rst
+++ b/api-docs/cdn-api-reference/methods/post-update-cdn-enabled-container-metadata-v1-account-container.rst
@@ -102,6 +102,8 @@ This operation does not return a response body.
 
 **Example: Update CDN-enabled container metadata HTTP response**
 
+**Note:** X-Cdn-Streaming-Uri and X-Cdn-Ios-Uri links will be discontinued on July 31, 2022. 
+
 .. code::
 
    HTTP/1.1 204 No Content

--- a/api-docs/cdn-api-reference/methods/put-cdn-enable-and-cdn-disable-a-container-v1-account-container.rst
+++ b/api-docs/cdn-api-reference/methods/put-cdn-enable-and-cdn-disable-a-container-v1-account-container.rst
@@ -168,6 +168,8 @@ This table shows the header parameters for the response:
 |                          |                         |streaming that uses HTTP|
 |                          |                         |Live Streaming from     |
 |                          |                         |Apple.                  |
+|                          |                         |**To be discontinued**  | 
+|                          |                         |**July 31, 2022**       |
 +--------------------------+-------------------------+------------------------+
 |X-Cdn-Ssl-Uri             |String                   |The URI for downloading |
 |                          |                         |the object over HTTPS,  |
@@ -182,6 +184,8 @@ This table shows the header parameters for the response:
 |                          |                         |streaming that uses HTTP|
 |                          |                         |Dynamic Streaming from  |
 |                          |                         |Adobe.                  |
+|                          |                         |**To be discontinued**  | 
+|                          |                         |**July 31, 2022**       |
 +--------------------------+-------------------------+------------------------+
 |X-Cdn-Uri                 |String                   |Indicates the URI that  |
 |                          |                         |you can combine with    |
@@ -196,6 +200,8 @@ This table shows the header parameters for the response:
 This operation does not return a response body.
 
 **Example: CDN-enable container HTTP response**
+
+**Note:** X-Cdn-Streaming-Uri and X-Cdn-Ios-Uri links will be discontinued on July 31, 2022.
 
 .. code::
 

--- a/api-docs/getting-started/examples/CDN-enabling-container.rst
+++ b/api-docs/getting-started/examples/CDN-enabling-container.rst
@@ -37,6 +37,8 @@ connection through the CDN.
 
 **Example: CDN-enable container and set TTL response**
 
+**Note:** X-Cdn-Streaming-Uri and X-Cdn-Ios-Uri links will be discontinued on July 31, 2022.
+
 .. code::
 
    HTTP/1.1 201 Created

--- a/api-docs/getting-started/examples/disable-CDN.rst
+++ b/api-docs/getting-started/examples/disable-CDN.rst
@@ -21,6 +21,8 @@ request is accepted for processing.
 
 **Example: Disable CDN for a container response**
 
+**Note:** X-Cdn-Streaming-Uri and X-Cdn-Ios-Uri links will be discontinued on July 31, 2022.
+
 .. code::
 
    HTTP/1.1 202 Accepted

--- a/api-docs/getting-started/examples/view-CDN-container-details.rst
+++ b/api-docs/getting-started/examples/view-CDN-container-details.rst
@@ -20,6 +20,8 @@ TTL <gsg-cdn-enabling-container>`.
 
 **Example:View CDN-enabled container details response**
 
+**Note:** X-Cdn-Streaming-Uri and X-Cdn-Ios-Uri links will be discontinued on July 31, 2022.
+
 .. code::
 
    HTTP/1.1 204 No Content

--- a/api-docs/use-cases/additional-cdn/cdn-enabled-containers-served-through-ssl.rst
+++ b/api-docs/use-cases/additional-cdn/cdn-enabled-containers-served-through-ssl.rst
@@ -19,6 +19,8 @@ requesting objects stored in CDN-enabled containers.
 **Example: CDN-enabled container metadata with SSL URI: HTTP
 response**
 
+**Note:** X-Cdn-Streaming-Uri and X-Cdn-Ios-Uri links will be discontinued on July 31, 2022.
+
 .. code::
 
     HTTP/1.1 204 No Content

--- a/api-docs/use-cases/additional-cdn/ios-streaming.rst
+++ b/api-docs/use-cases/additional-cdn/ios-streaming.rst
@@ -3,6 +3,8 @@
 iOS streaming
 ~~~~~~~~~~~~~
 
+**Note: X-Cdn-Streaming-Uri and X-Cdn-Ios-Uri links will be discontinued on July 31, 2022.**
+
 The Cloud Files CDN allows you to stream video to iOS devices without
 needing to convert your video. After you CDN-enable your container, you
 have the tools necessary for streaming media to multiple devices. To

--- a/api-docs/use-cases/additional-cdn/streaming-cdn-enabled-containers.rst
+++ b/api-docs/use-cases/additional-cdn/streaming-cdn-enabled-containers.rst
@@ -3,6 +3,8 @@
 Streaming CDN-enabled containers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+**Note: X-Cdn-Streaming-Uri and X-Cdn-Ios-Uri links will be discontinued on July 31, 2022.**
+
 In addition to the other headers associated with CDN, a **HEAD**
 operation against a CDN-enabled container returns the following
 streaming URIs to enable the streaming feature:

--- a/api-docs/use-cases/additional-storage/cdn-enabled-containers-served-through-ssl.rst
+++ b/api-docs/use-cases/additional-storage/cdn-enabled-containers-served-through-ssl.rst
@@ -19,6 +19,8 @@ requesting objects stored in CDN-enabled containers.
 **Example: CDN-enabled container metadata with SSL URI: HTTP
 response**
 
+**Note:** X-Cdn-Streaming-Uri and X-Cdn-Ios-Uri links will be discontinued on July 31, 2022. X-Cdn_Uri and X-Cdn-Ssl_Uri links will be unaffected.
+
 .. code::
 
     HTTP/1.1 204 No Content

--- a/api-docs/use-cases/additional-storage/ios-streaming.rst
+++ b/api-docs/use-cases/additional-storage/ios-streaming.rst
@@ -3,6 +3,8 @@
 iOS streaming
 ~~~~~~~~~~~~~
 
+**Note: X-Cdn-Streaming-Uri and X-Cdn-Ios-Uri links will be discontinued on July 31, 2022.**
+
 The Cloud Files CDN allows you to stream video to iOS devices without
 needing to convert your video. After you CDN-enable your container, you
 have the tools necessary for streaming media to multiple devices. To

--- a/api-docs/use-cases/additional-storage/streaming-cdn-enabled-containers.rst
+++ b/api-docs/use-cases/additional-storage/streaming-cdn-enabled-containers.rst
@@ -3,6 +3,8 @@
 Streaming CDN-enabled containers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+**Note: X-Cdn-Streaming-Uri and X-Cdn-Ios-Uri links will be discontinued on July 31, 2022.**
+
 In addition to the other headers associated with CDN, a **HEAD**
 operation against a CDN-enabled container returns the following
 streaming URIs to enable the streaming feature:


### PR DESCRIPTION
Updating Cloud Files API documentation to show that streaming URLs are going to be discontinued on July 31, 2022.