### PR TITLE
Replaced: Polyfill

### DIFF
--- a/api-docs/_templates/scripts.html
+++ b/api-docs/_templates/scripts.html
@@ -121,5 +121,5 @@
 </script>
 <script src="https://docs.rackspace.com/assets/bundle.js"></script>
 <script
-    src="https://polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries">
+    src="https://polyfill-fastly.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries">
 </script>


### PR DESCRIPTION
@the2hill 

url link: https://developer.rackspace.com/docs/cloud-files/v1/developer-guide/ does not map correctly to https://docs-ospc.rackspace.com/cloud-files/v1/

But this repo link is available in Readme.io https://docs-ospc.rackspace.com/cloud-files/v1/

Could you please review and merge the PR.
